### PR TITLE
Fix script naming error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,4 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry.scripts]
 sth = "search_that_hash.__main__:main"
-name-that-hash = "search_that_hash.__main__:main"
+search-that-hash = "search_that_hash.__main__:main"


### PR DESCRIPTION
Fixes an error where the console script is installed under the wrong name.

See the Discord for more info.