### PR TITLE
Removed illegal import

### DIFF
--- a/search_that_hash/cracker/offline_mod/offline.py
+++ b/search_that_hash/cracker/offline_mod/offline.py
@@ -1,3 +1,3 @@
 import subprocess as sp
-from mport search_that_hash.cracker.offline_mod import hashcat
+from search_that_hash.cracker.offline_mod import hashcat
 # Make a class here that calls both depending on the data provided


### PR DESCRIPTION
Just another thing, I'm getting syntax error for this line, and I just want to check why mport is there
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/search_that_hash/cracker/offline_mod/offline.py", line 2
    from mport search_that_hash.cracker.offline_mod import hashcat
               ^
SyntaxError: invalid syntax

@harens