### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Search-That-Hash searches the most popular hash cracking sites and automatically
 
 Couldn't find it in any API? 😢 STH automatically pipes your input into Hashcat 🥳
 
+Make sure to specifcy a wordlist if you want it to use hashcat with `-w /path/to/wordlist`, on windows? No worries, just add the arg `-hashcat_binary /path/to/hashcat/exe` as shown above😊 
+
 # 🔨 Installation
 
 Install Search-That-Hash as fast as you can read this README. No, seriously -- it's that easy  😎

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Search-That-Hash searches the most popular hash cracking sites and automatically
 
 Couldn't find it in any API? 😢 STH automatically pipes your input into Hashcat 🥳
 
-Make sure to specifcy a wordlist if you want it to use hashcat with `-w /path/to/wordlist`, on windows? No worries, just add the arg `-hashcat_binary /path/to/hashcat/exe` as shown above😊 
+Make sure to specify a wordlist if you want STH to use HashCat with `-w /path/to/wordlist`. If you are on Windows you must specify the path to your HashCat binary with the arg `-hashcat_binary /path/to/hashcat/exe` as shown above. 😊
 
 # 🔨 Installation
 


### PR DESCRIPTION
Update the readme to specify that you must provide a wordlist to STH for HashCat to work, and that you need to specify the path of the HashCat binary too if you're on Windows.