### PR TITLE
Added popular to API

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -184,14 +184,14 @@ dev = ["codecov (>=2.0.15)", "colorama (>=0.3.4)", "flake8 (>=3.7.7)", "tox (>=3
 
 [[package]]
 name = "name-that-hash"
-version = "1.8.0"
+version = "1.10.0"
 description = "The Modern Hash Identification System"
 category = "main"
 optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
-click = ">=7.1.2,<8.0.0"
+click = ">=7.1.2,<9.0.0"
 rich = ">=9.9,<11.0"
 
 [[package]]
@@ -512,8 +512,8 @@ loguru = [
     {file = "loguru-0.5.3.tar.gz", hash = "sha256:b28e72ac7a98be3d28ad28570299a393dfcd32e5e3f6a353dec94675767b6319"},
 ]
 name-that-hash = [
-    {file = "name-that-hash-1.8.0.tar.gz", hash = "sha256:f1f11dce70e0baf7521245abb4eb3a1563dac637791369561c5daba1aeb7fc97"},
-    {file = "name_that_hash-1.8.0-py3-none-any.whl", hash = "sha256:b3c1a0a1623649eac9fa2a149d0d277f244b46b4a533472eec53eedacde4dcb5"},
+    {file = "name-that-hash-1.10.0.tar.gz", hash = "sha256:aabe1a3e23f5f8ca1ef6522eb1adcd5c69b5fed3961371ed84a22fc86ee648a2"},
+    {file = "name_that_hash-1.10.0-py3-none-any.whl", hash = "sha256:cfb871f486d98728fec546f1d2c1b1e512665ffe58458f0915ade4b841d2ef36"},
 ]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ rich = ">=9.12.2,<11.0.0"
 coloredlogs = "^15.0"
 cloudscraper = "^1.2.56"
 
-
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"
 coverage = {extras = ["toml"], version = "^5.5"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,18 +15,18 @@ idna==2.10; python_version >= "2.7" and python_full_version < "3.0.0" or python_
 importlib-metadata==3.7.0; python_version < "3.8" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
 iniconfig==1.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 loguru==0.5.3; python_version >= "3.5"
-name-that-hash==1.8.0; python_version >= "3.6" and python_version < "4.0"
+name-that-hash==1.10.0; python_version >= "3.6" and python_version < "4.0"
 packaging==20.9; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 pygments==2.8.0; python_version >= "3.6" and python_version < "4.0"
 pyparsing==2.4.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pyreadline==2.1; python_version >= "2.7" and python_full_version < "3.0.0" and sys_platform == "win32" or python_full_version >= "3.5.0" and sys_platform == "win32"
-pytest-cov==2.11.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+pytest-cov==2.12.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 pytest==6.2.4; python_version >= "3.6"
 requests-toolbelt==0.9.1
 requests==2.25.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-rich==10.1.0; python_version >= "3.6" and python_version < "4.0"
+rich==10.2.1; python_version >= "3.6" and python_version < "4.0"
 toml==0.10.2; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 typing-extensions==3.7.4.3; python_version >= "3.6" and python_version < "3.8"
 urllib3==1.26.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"

--- a/search_that_hash/api.py
+++ b/search_that_hash/api.py
@@ -4,9 +4,9 @@ from search_that_hash.cracker import handler
 import json
 
 
-def return_as_json(hashes, api_key=None):
+def return_as_json(hashes, api_key=None, popular=False):
 
-    config = config_object.api_config(hashes, api_key)
+    config = config_object.api_config(hashes, api_key, popular)
     config["greppable"] = True
     cracking_handler = handler.Handler(config)
 
@@ -15,9 +15,9 @@ def return_as_json(hashes, api_key=None):
     return json_result
 
 
-def return_as_fast_json(hashes, api_key=None):
+def return_as_fast_json(hashes, api_key=None, popular=False):
 
-    config = config_object.api_config(hashes, api_key)
+    config = config_object.api_config(hashes, api_key, popular)
     cracking_handler = handler.Handler(config)
 
     json_result = cracking_handler.start()

--- a/search_that_hash/config_object.py
+++ b/search_that_hash/config_object.py
@@ -30,9 +30,9 @@ def cli_config(kwargs):
     return config
 
 
-def api_config(hashes: str, sth_api: str = None):
+def api_config(hashes: str, sth_api: str = None, popular=False):
     config = default_config()
-    config["hashes"] = create_hash_config(hashes)
+    config["hashes"] = create_hash_config(hashes, popular)
     config["api"] = True
     if sth_api:
         config["api_keys"]["STH"] = sth_api
@@ -74,8 +74,8 @@ def default_config():
     return json_contents
 
 
-def create_hash_config(hashes):
+def create_hash_config(hashes, popular=False):
     # Gets the results from name-that-hash
     logging.debug("Called NTH to get hash types")
-    nth_result_types = json.loads(nth.api_return_hashes_as_json(hashes))
+    nth_result_types = json.loads(nth.api_return_hashes_as_json(hashes, {"popular_only": popular}))
     return nth_result_types

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -13,6 +13,14 @@ def test_it_works():
 
     assert x is not None
 
+def test_api_popular():
+
+    hashes = ["5d41402abc4b2a76b9719d911017c592"]
+
+    x = api.return_as_json(hashes, popular=True)
+
+    assert x is not None
+
 
 def test_it_works_fast():
 
@@ -22,6 +30,13 @@ def test_it_works_fast():
 
     assert x is not None
 
+def test_it_works_fast_popular():
+
+    hashes = ["5d41402abc4b2a76b9719d911017c592"]
+
+    x = api.return_as_fast_json(hashes, popular=True)
+
+    assert x is not None
 
 def test_password_in_md5():
 


### PR DESCRIPTION
We can now activate popular mode in STH, meaning it should only run if the hash is considered popular. This will allow us to use this in Ciphey.