### PR TITLE
Making the hash color scheme easier to read

### DIFF
--- a/search_that_hash/printing.py
+++ b/search_that_hash/printing.py
@@ -35,14 +35,14 @@ class Prettifier:
 
     @staticmethod
     def error_print(msg, chash):
-        console.print(f"\n\n[bold #011627 on #ff9f1c]{chash}[/bold #011627 on #ff9f1c]")
+        console.print(f"\n\n[bold #ffffff on #f08400]{chash}[/bold #ffffff on #ed0010]")
         console.print(
             f"\n[bold underline #E71D36]Error[/bold underline #E71D36]: [bold #E71D36]{msg}[/bold #E71D36]"
         )
 
     @staticmethod
     def sth_print(chash, result, type, verified):
-        console.print(f"\n\n[bold #011627 on #ff9f1c]{chash}[/bold #011627 on #ff9f1c]")
+        console.print(f"\n\n[bold #ffffff on #ed0010]{chash}[/bold #ffffff on #ed0010]")
         texts = (
             f"\n[bold underline #EC7F5B]Text[/bold underline #EC7F5B] : [bold #AFEADC on #005F5F]{result}[/bold #AFEADC on #005F5F]"
             + f"\n[bold underline #EC7F5B]Type[/bold underline #EC7F5B] : [bold #AFEADC on #005F5F]{type}[/bold #AFEADC on #005F5F]"
@@ -55,7 +55,7 @@ class Prettifier:
 
     @staticmethod
     def one_print(chash, result, site):
-        console.print(f"\n\n[bold #011627 on #ff9f1c]{chash}[/bold #011627 on #ff9f1c]")
+        console.print(f"\n\n[bold #ffffff on #ed0010]{chash}[/bold #ffffff on #ed0010]")
         console.print(
             f"\n[bold underline #EC7F5B]Text[/bold underline #EC7F5B] : [bold #AFEADC on #005F5F]{result}[/bold #AFEADC on #005F5F]"
             + f"\n[bold underline #EC7F5B]Site[/bold underline #EC7F5B] : [bold #AFEADC on #005F5F]Hashtoolkit[/bold #AFEADC on #005F5F]"


### PR DESCRIPTION
As raised by #120, the current color scheme makes it a bit hard to read the hash in the terminal. I've used colors in the current scheme, to provide a hopefully more readable hash. The comparison is provided below.

Old hash
![image](https://user-images.githubusercontent.com/11142547/136005560-fb85f481-fd21-474b-8d4c-56659c2e5c82.png)


New hash
![image](https://user-images.githubusercontent.com/11142547/136005429-aced6b78-58b9-455f-810c-adfb4ef4bda5.png)

New hash when highlighted
![image](https://user-images.githubusercontent.com/11142547/136005505-a95a248c-f7ce-40c0-b059-3661a516bd48.png)

@Jayy001 what do you think? Are there different colors you'd prefer?