### PR TITLE
path fix for macOS/Linux compat

### DIFF
--- a/search_that_hash/config_object.py
+++ b/search_that_hash/config_object.py
@@ -59,7 +59,7 @@ def default_config():
     appname = "Search-That-Hash"
     appauthor = "HashPals"
 
-    config_json = user_data_dir(appname, appauthor) + "\\config.json"
+    config_json = os.path.join(user_data_dir(appname, appauthor), "config.json")
 
     if not os.path.isfile(config_json):
         os.makedirs(user_data_dir(appname, appauthor))


### PR DESCRIPTION
'foo\bar' is invalid on macOS/Linux, os.path is already imported so let's use it...

fixes this problem:

![screenshot_pqSJES3G](https://github.com/user-attachments/assets/6bb84e4f-a4cc-4d55-945a-649f806574b7)
